### PR TITLE
added bower.json to allow users to download via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "color-me-sass",
+  "homepage": "http://richbray.me/cms/",
+  "authors": [
+    "Richard Bray <richardobray@yahoo.co.uk>"
+  ],
+  "description": "Colour library for the css preprocessor Sass.",
+  "main": "_color-me-sass.scss",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "color"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I've added a `bower.json` file to your directory in order to allow users to install your project via bower. If the pull is accepted please registering your project with bower.

Simply run this command in your cli within your projects directory:
```
$ bower register color-me-sass https://github.com/RichardBray/color-me-sass
```

_Side note_: bower requires you have `git tag` versioning attached to your repository. I went ahead and named this version `v1.3.1` since your site already had `v1.3`.